### PR TITLE
fix: guard randomInt range and improve hasKey

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -258,6 +258,10 @@ export function randomInt(min: number, max?: number): number {
 		max = min;
 		min = 0;
 	}
+	// Avoid NaN from modulo by zero and guard against invalid ranges
+	if (max <= min) {
+		return min;
+	}
 	return min + (crypto.getRandomValues(new Uint32Array(1))[0] % (max - min));
 }
 
@@ -281,7 +285,9 @@ export function randomString(minLength: number, maxLength?: number): string {
  * Checks if a value is an object with a specific key and provides a type guard for the key.
  */
 export function hasKey<T extends PropertyKey>(value: unknown, key: T): value is Record<T, unknown> {
-	return value !== null && typeof value === 'object' && value.hasOwnProperty(key);
+	return (
+		value !== null && typeof value === 'object' && Object.prototype.hasOwnProperty.call(value, key)
+	);
 }
 
 const unsafeObjectProperties = new Set(['__proto__', 'prototype', 'constructor', 'getPrototypeOf']);

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -268,6 +268,11 @@ describe('randomInt', () => {
 			expect(result).toBeGreaterThanOrEqual(10);
 		});
 	});
+
+	it('should return the lower bound when the range is empty or inverted', () => {
+		expect(randomInt(5, 5)).toBe(5);
+		expect(randomInt(10, 5)).toBe(10);
+	});
 });
 
 describe('randomString', () => {
@@ -366,6 +371,12 @@ describe('hasKey', () => {
 			const z: Expect<Equal<typeof x, unknown>> = true;
 			z;
 		}
+	});
+
+	it('should work when hasOwnProperty is overridden', () => {
+		const obj = { a: 1, hasOwnProperty: () => false };
+		const result = hasKey(obj, 'a');
+		expect(result).toEqual(true);
 	});
 });
 


### PR DESCRIPTION
## Summary
- prevent `randomInt` from returning NaN or out-of-range values when given invalid bounds
- harden `hasKey` against overridden `hasOwnProperty`
- add tests for edge cases in `randomInt` and `hasKey`

## Testing
- `pnpm --filter n8n-workflow test`
- `pnpm --filter n8n-workflow lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b4ae532083309fb28887eb13b6ce